### PR TITLE
Bump isnumeric dep to ^0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
-    "isnumeric": "^0.3.1",
+    "isnumeric": "^0.3.2",
     "viewport-dimensions": "^0.2.0"
   },
   "keywords": [


### PR DESCRIPTION
isnumeric didn't have a license, which made all downstream automatic license checkers fail.
Please merge and release. Thanks!