### PR TITLE
offsetWidth and offsetHeight as fourth argument

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -56,6 +56,8 @@ utilities.getCreatedElementHeight = function(parent, properties, content) {
 };
 
 var selfReferenceTriggers = [
+  'offsetWidth',
+  'offsetHeight',
   'perspective',
   'translate',
   'translate3d',
@@ -66,6 +68,7 @@ var selfReferenceTriggers = [
 ];
 
 var layoutYTriggers = [
+  'offsetHeight',
   'height',
   'top',
   'translateY'


### PR DESCRIPTION
### Hello! Thank you for your module.


I noticed useSelf was false when using those properties as fourth argument:

`units.convert("px", "10%", myElement, "offsetWidth")`

This was generating wrong results, since the parent offsetWidth can be different (if myElement as visible scroll, in exemple).

At least in all scenarios I am using, this fix made things work properly.
It was fun to read your code and I hope my little change helps somehow!