### PR TITLE
Make element measurement more robust

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -16,21 +16,24 @@ utilities.getCreatedElementDimensions = function(parent, properties, content) {
   var dimensions;
   var property;
 
-  // !important, to override any CSS cascading when inserted
-  style.position = 'absolute !important';
-  style.zIndex = "-2147483648 !important";
-  style.left = "0 !important";
-  style.top = "0 !important";
-  style.visibility = 'hidden !important';
-  // offset width/height include padding/border
-  style.padding = "0 !important";
-  style.border = "none !important";
-
+  var base_styles = {
+    position: "absolute",
+    zIndex: -2147483648,
+    left: 0,
+    top: 0,
+    visibility: "hidden",
+    // offset width/height include padding/border
+    padding: 0,
+    border: "0 hidden"
+  };
+  // "important", to override any CSS cascading when inserted  
+  for (property in base_styles)
+    style.setProperty(property, base_styles[property], "important"); 
   if (properties) {
     for (property in properties) {
       /* istanbul ignore else */
       if (properties.hasOwnProperty(property)) {
-        style[property] = properties[property];
+        style.setProperty(property, properties[property], "important");
       }
     }
   }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -16,11 +16,15 @@ utilities.getCreatedElementDimensions = function(parent, properties, content) {
   var dimensions;
   var property;
 
-  style.position = 'absolute';
-  style.zIndex = -2147483648;
-  style.left = 0;
-  style.top = 0;
-  style.visibility = 'hidden';
+  // !important, to override any CSS cascading when inserted
+  style.position = 'absolute !important';
+  style.zIndex = "-2147483648 !important";
+  style.left = "0 !important";
+  style.top = "0 !important";
+  style.visibility = 'hidden !important';
+  // offset width/height include padding/border
+  style.padding = "0 !important";
+  style.border = "none !important";
 
   if (properties) {
     for (property in properties) {


### PR DESCRIPTION
Tweak inline styles so that getCreatedElementDimensions is more robust to CSS cascading rules